### PR TITLE
DB seeder and table renaming

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,7 @@ dependencies {
     implementation 'org.flywaydb:flyway-database-postgresql'
     implementation 'me.paulschwarz:spring-dotenv:4.0.0'
     implementation 'org.mapstruct:mapstruct:1.6.3'
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
 
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'

--- a/src/main/java/io/github/two_rk_dev/pointeurback/controller/LevelController.java
+++ b/src/main/java/io/github/two_rk_dev/pointeurback/controller/LevelController.java
@@ -31,8 +31,8 @@ public class LevelController {
     }
 
     @GetMapping
-    public ResponseEntity<List<LevelDTO>> getAllLevels() {
-        List<LevelDTO> levels = levelService.getAll();
+    public ResponseEntity<List<LevelDetailsDTO>> getAllLevels() {
+        List<LevelDetailsDTO> levels = levelService.getAll();
         return ResponseEntity.ok(levels);
     }
 

--- a/src/main/java/io/github/two_rk_dev/pointeurback/model/Group.java
+++ b/src/main/java/io/github/two_rk_dev/pointeurback/model/Group.java
@@ -14,7 +14,7 @@ import java.util.Objects;
 @ToString
 @RequiredArgsConstructor
 @Entity
-@Table(name = "group")
+@Table(name = "groups")
 public class Group {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/io/github/two_rk_dev/pointeurback/seeder/DatabaseSeeder.java
+++ b/src/main/java/io/github/two_rk_dev/pointeurback/seeder/DatabaseSeeder.java
@@ -1,0 +1,119 @@
+package io.github.two_rk_dev.pointeurback.seeder;
+
+import io.github.two_rk_dev.pointeurback.model.*;
+import io.github.two_rk_dev.pointeurback.repository.*;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+@Profile("seed")
+public class DatabaseSeeder implements CommandLineRunner {
+    private final GroupRepository groupRepository;
+    private final LevelRepository levelRepository;
+    private final RoomRepository roomRepository;
+    private final TeacherRepository teacherRepository;
+    private final TeachingUnitRepository teachingUnitRepository;
+
+    public DatabaseSeeder(GroupRepository groupRepository, LevelRepository levelRepository, RoomRepository roomRepository, TeacherRepository teacherRepository, TeachingUnitRepository teachingUnitRepository) {
+        this.groupRepository = groupRepository;
+        this.levelRepository = levelRepository;
+        this.roomRepository = roomRepository;
+        this.teacherRepository = teacherRepository;
+        this.teachingUnitRepository = teachingUnitRepository;
+    }
+
+    @Override
+    public void run(String... args) {
+        Level l1 = new Level();
+        l1.setName("L1");
+        l1.setAbbreviation("L1");
+        Level l2 = new Level();
+        l2.setName("L2");
+        l2.setAbbreviation("L2");
+        Level l3 = new Level();
+        l3.setName("L3");
+        l3.setAbbreviation("L3");
+        levelRepository.saveAll(List.of(l1, l2, l3));
+
+        Group l1Group1 = new Group();
+        l1Group1.setName("L1Gp1");
+        l1Group1.setSize(100);
+        l1Group1.setLevel(l1);
+        Group l1Group2 = new Group();
+        l1Group2.setName("L1Gp2");
+        l1Group2.setSize(50);
+        l1Group2.setLevel(l1);
+        Group l2Group1 = new Group();
+        l2Group1.setName("L2Gp1");
+        l2Group1.setSize(150);
+        l2Group1.setLevel(l2);
+        Group l2Group2 = new Group();
+        l2Group2.setName("L2Gp2");
+        l2Group2.setSize(200);
+        l2Group2.setLevel(l2);
+        groupRepository.saveAll(List.of(l1Group1, l1Group2, l2Group1, l2Group2));
+
+        Room s001 = new Room();
+        s001.setName("S001");
+        s001.setAbbreviation("S001");
+        s001.setSize(100);
+        Room s002 = new Room();
+        s002.setName("S002");
+        s002.setAbbreviation("S002");
+        s002.setSize(200);
+        Room s003 = new Room();
+        s003.setName("S003");
+        s003.setAbbreviation("S003");
+        s003.setSize(150);
+        Room s101 = new Room();
+        s101.setName("S101");
+        s101.setAbbreviation("S101");
+        s101.setSize(250);
+        roomRepository.saveAll(List.of(s001, s002, s003, s101));
+
+        Teacher teacher1 = new Teacher();
+        teacher1.setName("Alix");
+        teacher1.setAbbreviation("ALX");
+        Teacher teacher2 = new Teacher();
+        teacher2.setName("Andry");
+        teacher2.setAbbreviation("ANDR");
+        Teacher teacher3 = new Teacher();
+        teacher3.setName("Angelo");
+        teacher3.setAbbreviation("ANG");
+        Teacher teacher4 = new Teacher();
+        teacher4.setName("Bertin");
+        teacher4.setAbbreviation("BERT");
+        Teacher teacher5 = new Teacher();
+        teacher5.setName("Cyprien");
+        teacher5.setAbbreviation("CYPR");
+        Teacher teacher6 = new Teacher();
+        teacher6.setName("Jean Christian RALAIVAO");
+        teacher6.setAbbreviation("JCR");
+        teacherRepository.saveAll(List.of(teacher1, teacher2, teacher3, teacher4, teacher5, teacher6, teacher6));
+
+        TeachingUnit tu1 = new TeachingUnit();
+        tu1.setName("Mathématiques Appliquées");
+        tu1.setAbbreviation("MATH");
+        tu1.setLevel(l1);
+        TeachingUnit tu2 = new TeachingUnit();
+        tu2.setName("Programmation Web");
+        tu2.setAbbreviation("PROG");
+        tu2.setLevel(l2);
+        TeachingUnit tu3 = new TeachingUnit();
+        tu3.setName("Base de Données");
+        tu3.setAbbreviation("BDD");
+        tu3.setLevel(l2);
+        TeachingUnit tu4 = new TeachingUnit();
+        tu4.setName("Théorie des Réseaux");
+        tu4.setAbbreviation("TRES");
+        tu4.setLevel(l1);
+        TeachingUnit tu5 = new TeachingUnit();
+        tu5.setName("Langage C");
+        tu5.setAbbreviation("LANG");
+        tu5.setLevel(l1);
+        teachingUnitRepository.saveAll(List.of(tu1, tu2, tu3, tu4, tu5, tu5));
+    }
+}

--- a/src/main/java/io/github/two_rk_dev/pointeurback/service/LevelService.java
+++ b/src/main/java/io/github/two_rk_dev/pointeurback/service/LevelService.java
@@ -6,7 +6,8 @@ import java.util.List;
 
 public interface LevelService {
     LevelDTO createLevel(CreateLevelDTO dto);
-    List<LevelDTO> getAll();
+
+    List<LevelDetailsDTO> getAll();
     LevelDetailsDTO getDetails(Long Id);
     LevelDTO updateLevel(Long id, UpdateLevelDTO dto);
     void deleteLevel (Long id);

--- a/src/main/java/io/github/two_rk_dev/pointeurback/service/implementation/LevelServiceImpl.java
+++ b/src/main/java/io/github/two_rk_dev/pointeurback/service/implementation/LevelServiceImpl.java
@@ -10,8 +10,12 @@ import io.github.two_rk_dev.pointeurback.model.Group;
 import io.github.two_rk_dev.pointeurback.model.Level;
 import io.github.two_rk_dev.pointeurback.model.ScheduleItem;
 import io.github.two_rk_dev.pointeurback.model.TeachingUnit;
-import io.github.two_rk_dev.pointeurback.repository.*;
+import io.github.two_rk_dev.pointeurback.repository.GroupRepository;
+import io.github.two_rk_dev.pointeurback.repository.LevelRepository;
+import io.github.two_rk_dev.pointeurback.repository.ScheduleItemRepository;
+import io.github.two_rk_dev.pointeurback.repository.TeachingUnitRepository;
 import io.github.two_rk_dev.pointeurback.service.LevelService;
+import jakarta.transaction.Transactional;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -50,10 +54,11 @@ public class LevelServiceImpl implements LevelService {
         return levelMapper.toDto(savedLevel);
     }
 
+    @Transactional
     @Override
-    public List<LevelDTO> getAll() {
+    public List<LevelDetailsDTO> getAll() {
         List<Level> existing = levelRepository.findAll();
-        return levelMapper.toDtoList(existing);
+        return existing.stream().map(levelMapper::toDetailsDto).toList();
     }
 
     @Override

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -8,7 +8,7 @@ spring:
   jpa:
     hibernate:
       ddl-auto: validate
-    show-sql: true
+    show-sql: false
     properties:
       hibernate:
         format_sql: true

--- a/src/main/resources/db/migration/V1__Initial_schema.sql
+++ b/src/main/resources/db/migration/V1__Initial_schema.sql
@@ -41,7 +41,8 @@ CREATE TABLE teaching_unit (
 );
 
 -- Création de la table Group
-CREATE TABLE "group" (
+CREATE TABLE groups
+(
                          group_id BIGSERIAL PRIMARY KEY,
     level_id BIGINT NOT NULL,
     name VARCHAR(255) NOT NULL,
@@ -85,7 +86,7 @@ CREATE TABLE schedule_item_groups
     group_id         BIGINT NOT NULL,
     CONSTRAINT fk_schedule_item_groups_group
         FOREIGN KEY (group_id)
-            REFERENCES "group" (group_id)
+            REFERENCES groups (group_id)
             ON DELETE CASCADE,
     CONSTRAINT fk_schedule_item_groups_schedule_item
         FOREIGN KEY (schedule_item_id)
@@ -96,7 +97,7 @@ CREATE TABLE schedule_item_groups
 
 -- Création des index pour améliorer les performances
 CREATE INDEX idx_teaching_unit_level_id ON teaching_unit(level_id);
-CREATE INDEX idx_group_level_id ON "group"(level_id);
+CREATE INDEX idx_group_level_id ON groups (level_id);
 CREATE INDEX idx_scheduler_teacher_id ON schedule_item(teacher_id);
 CREATE INDEX idx_scheduler_teaching_unit_id ON schedule_item(teaching_unit_id);
 CREATE INDEX idx_scheduler_room_id ON schedule_item(room_id);
@@ -107,5 +108,5 @@ COMMENT ON TABLE level IS 'Table des niveaux d''enseignement';
 COMMENT ON TABLE teacher IS 'Table des enseignants';
 COMMENT ON TABLE room IS 'Table des salles de classe';
 COMMENT ON TABLE teaching_unit IS 'Table des unités d''enseignement';
-COMMENT ON TABLE "group" IS 'Table des groupes d''étudiants';
+COMMENT ON TABLE groups IS 'Table des groupes d''étudiants';
 COMMENT ON TABLE schedule_item IS 'Table de planification des cours';


### PR DESCRIPTION
Changes proposed:

**Database Schema and Naming Consistency:**

* Renamed the SQL table from `"group"` to `groups` throughout the schema, including table creation, foreign key references, index creation, and comments, to avoid reserved keyword conflicts and improve consistency.
* Updated the JPA entity `Group` to map to the new `groups` table instead of `"group"`.

**Service and Controller Logic Updates:**

* Changed the `LevelService` interface and its implementation so that `getAll()` now returns a list of `LevelDetailsDTO` instead of `LevelDTO`, and updated the controller to match this new return type for the endpoint.
* Added the `@Transactional` annotation to the `getAll()` method in `LevelServiceImpl` to ensure proper transaction management when retrieving levels.

**Development and Testing Improvements:**

* Added a new `DatabaseSeeder` component (active only on the `seed` profile) to populate the database with sample data for levels, groups, rooms, teachers, and teaching units, facilitating easier development and testing.
* Disabled SQL logging in the application configuration for cleaner logs by setting `show-sql: false` in `application.yml`.