### PR TITLE
Start and end to OffsetDateTime

### DIFF
--- a/src/main/java/io/github/two_rk_dev/pointeurback/mapper/ScheduleItemMapper.java
+++ b/src/main/java/io/github/two_rk_dev/pointeurback/mapper/ScheduleItemMapper.java
@@ -11,7 +11,7 @@ import io.github.two_rk_dev.pointeurback.model.*;
 import org.jetbrains.annotations.NotNull;
 import org.mapstruct.*;
 
-import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Objects;
@@ -55,9 +55,9 @@ public interface ScheduleItemMapper {
     @BeanMapping(nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE)
     void updateFromDto(UpdateScheduleItemDTO dto, @MappingTarget ScheduleItem entity);
 
-    default LocalDateTime parseDateTime(String dateTimeStr) {
+    default OffsetDateTime parseDateTime(String dateTimeStr) {
         if (dateTimeStr == null) return null;
-        return LocalDateTime.parse(dateTimeStr, DATE_TIME_FORMATTER);
+        return OffsetDateTime.parse(dateTimeStr, DATE_TIME_FORMATTER);
     }
 
     default ScheduleItem createFromDto(@NotNull CreateScheduleItemDTO dto,

--- a/src/main/java/io/github/two_rk_dev/pointeurback/model/ScheduleItem.java
+++ b/src/main/java/io/github/two_rk_dev/pointeurback/model/ScheduleItem.java
@@ -6,7 +6,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
-import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -22,9 +22,9 @@ public class ScheduleItem {
     private Long id;
 
     @Setter
-    private LocalDateTime startTime;
+    private OffsetDateTime startTime;
     @Setter
-    private LocalDateTime endTime;
+    private OffsetDateTime endTime;
 
     @Setter
     @ManyToOne

--- a/src/main/java/io/github/two_rk_dev/pointeurback/repository/ScheduleItemRepository.java
+++ b/src/main/java/io/github/two_rk_dev/pointeurback/repository/ScheduleItemRepository.java
@@ -5,7 +5,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
 import java.util.List;
 
 public interface ScheduleItemRepository extends JpaRepository<ScheduleItem, Long> {
@@ -26,12 +26,12 @@ public interface ScheduleItemRepository extends JpaRepository<ScheduleItem, Long
             "WHERE ((si.room.id = :roomId OR si.teacher.id = :teacherId OR g.id IN :groupIds) " +
             "AND (si.startTime < :endTime AND si.endTime > :startTime))")
     List<ScheduleItem> findConflictingSchedule(
-            @Param("startTime") LocalDateTime startTime,
-            @Param("endTime") LocalDateTime endTime,
+            @Param("startTime") OffsetDateTime startTime,
+            @Param("endTime") OffsetDateTime endTime,
             @Param("roomId") Long roomId,
             @Param("teacherId") Long teacherId,
             @Param("groupIds") List<Long> groupIds);
 
-    List<ScheduleItem> findByStartTimeBetween(LocalDateTime startTime, LocalDateTime endTime);
+    List<ScheduleItem> findByStartTimeBetween(OffsetDateTime startTime, OffsetDateTime endTime);
 }
 

--- a/src/main/java/io/github/two_rk_dev/pointeurback/service/implementation/ScheduleServiceImpl.java
+++ b/src/main/java/io/github/two_rk_dev/pointeurback/service/implementation/ScheduleServiceImpl.java
@@ -12,7 +12,7 @@ import io.github.two_rk_dev.pointeurback.service.ScheduleService;
 import org.jetbrains.annotations.Nullable;
 import org.springframework.stereotype.Service;
 
-import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -36,8 +36,8 @@ public class ScheduleServiceImpl implements ScheduleService {
 
     @Override
     public List<ScheduleItemDTO> getSchedule(@Nullable Long levelId, @Nullable Long groupId, String start, String endTime) {
-        LocalDateTime startDateTime = scheduleItemMapper.parseDateTime(start);
-        LocalDateTime endDateTime = scheduleItemMapper.parseDateTime(endTime);
+        OffsetDateTime startDateTime = scheduleItemMapper.parseDateTime(start);
+        OffsetDateTime endDateTime = scheduleItemMapper.parseDateTime(endTime);
 
         if (startDateTime == null || endDateTime == null) {
             throw new IllegalArgumentException("Start and end times must be provided");


### PR DESCRIPTION
This pull request updates the handling of schedule item date and time fields throughout the backend codebase to use `OffsetDateTime` instead of `LocalDateTime`. This change ensures that time zone information is preserved and improves consistency in date/time operations across the application.

**Date and time type migration:**

* Changed all references to `LocalDateTime` to `OffsetDateTime` in the `ScheduleItem` entity, including the `startTime` and `endTime` fields. [[1]](diffhunk://#diff-be6abe6a7f7be325ea777598e4efa8add3a9f2e55b1b367162f62f03dad9af0cL9-R9) [[2]](diffhunk://#diff-be6abe6a7f7be325ea777598e4efa8add3a9f2e55b1b367162f62f03dad9af0cL25-R27)
* Updated the `ScheduleItemMapper` methods and imports to use `OffsetDateTime`, including the `parseDateTime` utility method. [[1]](diffhunk://#diff-b4524bd093788824c740a6107630a2ae4f3624ba58c9be9c39c59986317f434bL14-R14) [[2]](diffhunk://#diff-b4524bd093788824c740a6107630a2ae4f3624ba58c9be9c39c59986317f434bL58-R60)
* Updated the `ScheduleItemRepository` method signatures and imports to use `OffsetDateTime` for querying schedule items. [[1]](diffhunk://#diff-5bbcaf630e0236f11937f99ab64708c9205e28b626d7ff4ded7e6675a2969c84L8-R8) [[2]](diffhunk://#diff-5bbcaf630e0236f11937f99ab64708c9205e28b626d7ff4ded7e6675a2969c84L29-R35)
* Refactored the `ScheduleServiceImpl` service to use `OffsetDateTime` when parsing and handling schedule query parameters. [[1]](diffhunk://#diff-01a9c4e26b275dcffa55cfe78768b9d910362c80c6d8a41c2870faf20610760cL15-R15) [[2]](diffhunk://#diff-01a9c4e26b275dcffa55cfe78768b9d910362c80c6d8a41c2870faf20610760cL39-R40)