### PR TITLE
fix: Find schedule conflicts with the new time interval, not the old one

### DIFF
--- a/src/main/java/io/github/two_rk_dev/pointeurback/service/implementation/ScheduleServiceImpl.java
+++ b/src/main/java/io/github/two_rk_dev/pointeurback/service/implementation/ScheduleServiceImpl.java
@@ -59,9 +59,11 @@ public class ScheduleServiceImpl implements ScheduleService {
         ScheduleItem existingItem = scheduleItemRepository.findById(id)
                 .orElseThrow(() -> new ScheduleItemNotFoundException("Schedule item not found with id: " + id));
 
+        OffsetDateTime newStart = scheduleItemMapper.parseDateTime(dto.startTime());
+        OffsetDateTime newEnd = scheduleItemMapper.parseDateTime(dto.endTime());
         List<ScheduleItem> conflictingItems = scheduleItemRepository.findConflictingSchedule(
-                existingItem.getStartTime(),
-                existingItem.getEndTime(),
+                newStart,
+                newEnd,
                 existingItem.getRoom().getId(),
                 existingItem.getTeacher().getId(),
                 dto.groupIds()


### PR DESCRIPTION
This pull request updates the logic for detecting schedule conflicts when updating a schedule item. Instead of using the existing item's start and end times, it now checks for conflicts using the new start and end times provided in the update request.

Schedule conflict detection update:

* In `ScheduleServiceImpl.java`, the conflict check in `updateScheduleItem` now uses the parsed `startTime` and `endTime` from the `UpdateScheduleItemDTO` instead of the existing item's times.