### PR TITLE
Cascade teaching unit deletion to schedule

### DIFF
--- a/src/main/resources/db/migration/V1__Initial_schema.sql
+++ b/src/main/resources/db/migration/V1__Initial_schema.sql
@@ -77,7 +77,7 @@ CREATE TABLE schedule_item
     CONSTRAINT fk_scheduler_teaching_unit
         FOREIGN KEY (teaching_unit_id)
             REFERENCES teaching_unit (teaching_unit_id)
-            ON DELETE SET NULL,
+            ON DELETE CASCADE,
     CONSTRAINT fk_scheduler_room
         FOREIGN KEY (room_id)
             REFERENCES room (room_id)


### PR DESCRIPTION
Because a schedule exists for a teaching unit.