### PR TITLE
Fix: accept null roomId

### DIFF
--- a/src/main/java/io/github/two_rk_dev/pointeurback/mapper/ScheduleItemMapper.java
+++ b/src/main/java/io/github/two_rk_dev/pointeurback/mapper/ScheduleItemMapper.java
@@ -86,9 +86,12 @@ public interface ScheduleItemMapper {
             throw new TeachingUnitNotFoundException("TeachingUnit not found with id: " + dto.teachingUnitId());
         }
 
-        Room room = roomProvider.apply(dto.roomId());
-        if (room == null) {
-            throw new RoomNotFoundException("Room not found with id: " + dto.roomId());
+        Room room = null;
+        if (dto.roomId() != null) {
+            room = roomProvider.apply(dto.roomId());
+            if (room == null) {
+                throw new RoomNotFoundException("Room not found with id: " + dto.roomId());
+            }
         }
 
         ScheduleItem item = fromCreateDto(dto);
@@ -154,7 +157,7 @@ public interface ScheduleItemMapper {
                 throw new RoomNotFoundException("Room not found with id: " + dto.roomId());
             }
             entity.setRoom(room);
-        }
+        } else entity.setRoom(null);
 
         if (entity.getEndTime().isBefore(entity.getStartTime())) {
             throw new IllegalStateException("End time cannot be before startTime time");

--- a/src/main/java/io/github/two_rk_dev/pointeurback/repository/ScheduleItemRepository.java
+++ b/src/main/java/io/github/two_rk_dev/pointeurback/repository/ScheduleItemRepository.java
@@ -23,7 +23,7 @@ public interface ScheduleItemRepository extends JpaRepository<ScheduleItem, Long
 
     @Query("SELECT DISTINCT si FROM ScheduleItem si " +
             "LEFT JOIN si.groups g " +
-            "WHERE ((si.room.id = :roomId OR si.teacher.id = :teacherId OR g.id IN :groupIds) " +
+           "WHERE (((:roomId <> NULL AND si.room.id = :roomId) OR si.teacher.id = :teacherId OR g.id IN :groupIds) " +
             "AND (si.startTime < :endTime AND si.endTime > :startTime))")
     List<ScheduleItem> findConflictingSchedule(
             @Param("startTime") OffsetDateTime startTime,

--- a/src/main/java/io/github/two_rk_dev/pointeurback/service/implementation/ScheduleServiceImpl.java
+++ b/src/main/java/io/github/two_rk_dev/pointeurback/service/implementation/ScheduleServiceImpl.java
@@ -6,6 +6,7 @@ import io.github.two_rk_dev.pointeurback.dto.UpdateScheduleItemDTO;
 import io.github.two_rk_dev.pointeurback.exception.GroupNotFoundException;
 import io.github.two_rk_dev.pointeurback.exception.ScheduleItemNotFoundException;
 import io.github.two_rk_dev.pointeurback.mapper.ScheduleItemMapper;
+import io.github.two_rk_dev.pointeurback.model.Room;
 import io.github.two_rk_dev.pointeurback.model.ScheduleItem;
 import io.github.two_rk_dev.pointeurback.repository.*;
 import io.github.two_rk_dev.pointeurback.service.ScheduleService;
@@ -64,7 +65,7 @@ public class ScheduleServiceImpl implements ScheduleService {
         List<ScheduleItem> conflictingItems = scheduleItemRepository.findConflictingSchedule(
                 newStart,
                 newEnd,
-                existingItem.getRoom().getId(),
+                Optional.ofNullable(existingItem.getRoom()).map(Room::getId).orElse(null),
                 existingItem.getTeacher().getId(),
                 dto.groupIds()
         );
@@ -108,7 +109,7 @@ public class ScheduleServiceImpl implements ScheduleService {
         List<ScheduleItem> conflictingItems = scheduleItemRepository.findConflictingSchedule(
                 newItem.getStartTime(),
                 newItem.getEndTime(),
-                newItem.getRoom().getId(),
+                Optional.ofNullable(newItem.getRoom()).map(Room::getId).orElse(null),
                 newItem.getTeacher().getId(),
                 dto.groupIds()
         );


### PR DESCRIPTION
Closes #17

This pull request addresses improvements and bug fixes related to handling nullable `Room` fields in schedule items, as well as correcting logic in the repository query for conflict detection. The changes ensure that schedule items can be created or updated without a room, and that conflict checks work correctly when the room is null.

**Null handling and validation improvements:**

* Updated `ScheduleItemMapper` methods to handle cases where `roomId` is null, allowing schedule items to be created or updated without a room, and setting the room to null when appropriate. [[1]](diffhunk://#diff-b4524bd093788824c740a6107630a2ae4f3624ba58c9be9c39c59986317f434bL89-R95) [[2]](diffhunk://#diff-b4524bd093788824c740a6107630a2ae4f3624ba58c9be9c39c59986317f434bL157-R160)

* Modified service layer (`ScheduleServiceImpl`) to safely handle potential null `Room` values when checking for conflicting schedule items, using `Optional.ofNullable(...).map(Room::getId).orElse(null)`. [[1]](diffhunk://#diff-01a9c4e26b275dcffa55cfe78768b9d910362c80c6d8a41c2870faf20610760cL67-R68) [[2]](diffhunk://#diff-01a9c4e26b275dcffa55cfe78768b9d910362c80c6d8a41c2870faf20610760cL111-R112)

**Repository query logic fix:**

* Corrected the JPQL query in `ScheduleItemRepository` to properly handle null `roomId` values when searching for conflicting schedule items, improving the accuracy of conflict detection.

**Imports:**

* Added missing import for `Room` in `ScheduleServiceImpl.java` to support the above changes.